### PR TITLE
Spells page styles

### DIFF
--- a/app/assets/stylesheets/spells.scss
+++ b/app/assets/stylesheets/spells.scss
@@ -1,8 +1,13 @@
 @import "utilities/variables";
 
 .spell-tile {
-    height: 74px !important;
+    $tile-dimension: 100px;
+    width: $tile-dimension;
+    height: $tile-dimension;
     white-space: normal;
+    padding: 2px;
+    overflow: scroll;
+    line-height: 1.2em;
 }
 
 .spell__notfound {
@@ -27,4 +32,15 @@
 
 .spell-modal .modal-header {
     border-bottom: 2px solid $color-tabasco !important;
+}
+
+
+// Media Queries
+@media screen and (max-width: 490px) {
+
+    .spell-tile {
+        $tile-dimension: 80px;
+        width: $tile-dimension;
+        height: $tile-dimension;
+    }
 }

--- a/app/views/spells/index.html.erb
+++ b/app/views/spells/index.html.erb
@@ -14,8 +14,8 @@
           <%= form_tag spells_path, method: :get, class: "form-inline" do %>
             <%= hidden_field_tag :klass, params[:klass] %>
             <div class="form-group pull-right">
-              <%= label :search, :name, "Name Search:" %>
-              <%= text_field_tag :name, params[:name], placeholder: "Search text...", class: "form-control" %>
+              <%= label :search, :name, "Spell Search:" %>
+              <%= text_field_tag :name, params[:name], placeholder: "enter spell name", class: "form-control" %>
               <%= submit_tag "Search", name: nil, class: "btn btn-primary" %>
             </div>
           <% end %>

--- a/app/views/spells/index.html.erb
+++ b/app/views/spells/index.html.erb
@@ -23,7 +23,7 @@
 
     <div class="row">
       <% @spells.each do |spell| %>
-        <div id="<%= spell.name %>" class="bottom20 spell col-xs-2">
+        <div id="<%= spell.name %>" class="bottom20 spell col-sm-2 col-xs-3">
           <button id="<%= spell.id %>" class="btn btn-default spell-tile btn-block align-middle" data-toggle="modal" data-target="#spell-info-modal-<%= spell.id %>">
             <%= spell.name %>
           </button>

--- a/app/views/spells/index.html.erb
+++ b/app/views/spells/index.html.erb
@@ -9,16 +9,18 @@
         </h3>
       </div>
 
-      <div class="col-xs-12 col-md-6">
-        <%= form_tag spells_path, method: :get, class: "form-inline" do %>
-          <%= hidden_field_tag :klass, params[:klass] %>
-          <div class="form-group pull-right">
-            <%= label :search, :name, "Name Search:" %>
-            <%= text_field_tag :name, params[:name], placeholder: "Search text...", class: "form-control" %>
-            <%= submit_tag "Search", name: nil, class: "btn btn-primary" %>
-          </div>
-        <% end %>
-      </div>
+      <div class="row">
+        <div class="col-xs-12 col-md-6">
+          <%= form_tag spells_path, method: :get, class: "form-inline" do %>
+            <%= hidden_field_tag :klass, params[:klass] %>
+            <div class="form-group pull-right">
+              <%= label :search, :name, "Name Search:" %>
+              <%= text_field_tag :name, params[:name], placeholder: "Search text...", class: "form-control" %>
+              <%= submit_tag "Search", name: nil, class: "btn btn-primary" %>
+            </div>
+          <% end %>
+        </div>
+      </div> <!-- row -->
     </div>
 
     <div class="row">


### PR DESCRIPTION
Hey Tek! This app is awesome! Sadly, I haven't played D&D (yet...), but I love that you've made all of that book-looking-up info for spells so easy to access. Niiiiice. Since the spells page is really the only part of the app I understand, I thought I'd do a little tweaking to the css to help with some of that text-overflow that was going on. It's not completely solved, but it is improved. 

![spells](https://user-images.githubusercontent.com/8680712/28492711-ba3c4602-6ecd-11e7-9d62-c96541bdd61d.gif)